### PR TITLE
Fix: ColorSchemeの変更時にモーダルに反映され変更時にモーダルに反映されないバモーダルに反映されないバグに対応

### DIFF
--- a/Search Assistant/Search Assistant/Search_AssistantApp.swift
+++ b/Search Assistant/Search Assistant/Search_AssistantApp.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 @main
 struct Search_AssistantApp: App {
-    @AppStorage("colorScheme") private var colorScheme = SAColorScheme.dark.rawValue
+    @AppStorage("colorScheme") private var appStorageColorScheme = SAColorScheme.dark.rawValue
     @StateObject private var viewRouter = ViewRouter.shared
-    
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -15,9 +15,13 @@ struct Search_AssistantApp: App {
                     ContentView()
                 }
             }
-            .preferredColorScheme(
-                colorScheme == "System" ? .none : colorScheme == "Light" ? .light : .dark
-            )
+            .preferredColorScheme({
+                return switch self.appStorageColorScheme {
+                case "Dark": .dark
+                case "Light": .light
+                default: .none
+                }
+            }())
         }
     }
 }

--- a/Search Assistant/Search Assistant/Views/View/ContentView/ContentView.swift
+++ b/Search Assistant/Search Assistant/Views/View/ContentView/ContentView.swift
@@ -4,6 +4,7 @@ struct ContentView: View {
     @StateObject private var vm = ContentViewModel()
     @FocusState private var isFocused
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
 
     var body: some View {
         VStack(spacing: 0) {
@@ -48,6 +49,7 @@ struct ContentView: View {
         // SettingsViewの表示設定
         .sheet(isPresented: $vm.isPresesntedSettingsView) {
             SettingView(vm: vm)
+                .preferredColorScheme(colorScheme)
         }
         // オートフォーカス有効 & アプリが開かれた
         .onAppear {

--- a/Search Assistant/Search Assistant/Views/View/SettingView/SettingView.swift
+++ b/Search Assistant/Search Assistant/Views/View/SettingView/SettingView.swift
@@ -7,11 +7,11 @@ enum SAColorScheme: String {
 }
 
 struct SettingView: View {
-    @AppStorage("colorScheme") private var colorScheme = SAColorScheme.dark.rawValue
+    @AppStorage("colorScheme") private var appStorageColorScheme = SAColorScheme.dark.rawValue
     @AppStorage("openInSafariView") private var openInSafariView = true
     @ObservedObject private(set) var vm: ContentViewModel
     @Environment(\.scenePhase) private var scenePhase
-    
+
     var body: some View {
         NavigationStack {
             List {
@@ -37,7 +37,7 @@ struct SettingView: View {
                 }
                 // 外観モードセクション
                 Section {
-                    Picker("Color Scheme", selection: $colorScheme) {
+                    Picker("Color Scheme", selection: $appStorageColorScheme) {
                         Text("Light").tag(SAColorScheme.light.rawValue)
                         Text("Dark").tag(SAColorScheme.dark.rawValue)
                         Text("System").tag(SAColorScheme.system.rawValue)


### PR DESCRIPTION
現在エントリポイントのViewに対してpreferredColorSchemeを設定しても、それが表示中のモーダルに反映されないバグ？がある。それに対応するため、モーダルの呼び出し元で環境変数colorSchemeを保持し、それをモーダルにpreferredColorSchemeで反映させるように対応した。
