### PR TITLE
Fix: ブラウザが開いた先で正しく検索が行われないバグを修正

### DIFF
--- a/Search Assistant/Search Assistant/Others/SearchURLCreater.swift
+++ b/Search Assistant/Search Assistant/Others/SearchURLCreater.swift
@@ -31,7 +31,7 @@ final class SearchURLCreater {
         ///
         ///
         /// 入力のパーセントエンコーディング
-        guard let percentEncodedInput = input.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        guard let percentEncodedInput = input.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
         else { throw SearchURLCreaterError.inputPercentEncodingFailure }
         ///
         ///


### PR DESCRIPTION
close #25 

検索URLの生成時、検索文字列のパーセントエンコードを行っているコードについて
```swift
input.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
```
`withAllowedCharacters`に`.urlQueryAllowed`が指定されていたけれども、ここで行なっている処理は parameter value のエンコードであって query のエンコードではないため適切ではない。
参考：https://developer.apple.com/documentation/foundation/nscharacterset/1416698-urlqueryallowed

parameter value の場合は記号関連はすべてエンコードして問題ないため、`.alphanumerics`が良さそうです。